### PR TITLE
fix: formattedCategories problem with categories that have a parent with same id

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,15 +39,19 @@ function getDeviceId() {
   return id;
 }
 
-function getParent(categories, item) {
+function getFirstChild(categories, item) {
   return (categories || []).find(category => (
-    Array.isArray(category.parents) && category.parents.indexOf(item.id) !== -1
+    !category.used
+    && Array.isArray(category.parents)
+    && category.parents.indexOf(item.id) !== -1
   ));
 }
 
 function formattedCategories(categories) {
   // Filter wrong formatted
-  const filteredCategories = (categories || []).filter(category => category && category.id);
+  const filteredCategories = (categories || [])
+    .filter(category => category && category.id)
+    .map(category => ({ id: category.id, parents: category.parents }));
 
   // Find the root node
   let item = filteredCategories.find(category => (
@@ -61,7 +65,8 @@ function formattedCategories(categories) {
 
   while (typeof item === 'object') {
     ids.push(item.id);
-    item = getParent(filteredCategories, item);
+    item.used = true;
+    item = getFirstChild(filteredCategories, item);
   }
   return ids;
 }

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -145,6 +145,54 @@ describe('BannerClient.getRecommendations', function () {
     });
   });
 
+  it('should not break with recursive categories', function () {
+    const categories = [
+      {
+        id: 'Medicina',
+        name: 'Medicina',
+        parents: ['Livros']
+      },
+      {
+        id: 'Livros',
+        name:'Livros'
+      },
+      {
+        id: 'Medicina',
+        name: 'Medicina',
+        parents: ['Medicina']
+      }
+    ];
+
+    const paramsClient = {
+      source: 'desktop',
+      page: 'home',
+      showLayout: true,
+      categories,
+    };
+
+    const params = {
+      categoryId: ['Livros', 'Medicina', 'Medicina'],
+      homologation: undefined,
+      page: 'home',
+      productId: undefined,
+      showLayout: true,
+      source: 'desktop',
+      tagId: [],
+      url: undefined,
+      userId: undefined,
+    };
+
+    this.ajaxStub.yieldsTo('success', {});
+
+    return BannerClient.getRecommendations(paramsClient).then(() => {
+      expect(this.ajaxStub)
+        .to
+        .have
+        .been
+        .calledWithMatch(sinon.match({ params }));
+    });
+  });
+
   it('should pass formattedTags to ajax request', function () {
     const tags = [
       {


### PR DESCRIPTION
Corrigindo bug do @rossicristian em categorias nesse formato:

```javascript
[
  { "id": "Livros", "parents": null },
  { "id": "Medicina", "parents": "Livros" },
  { "id": "Medicina", "parents": "Medicina" }
]
```