### PR TITLE
update banner-server host and remove deviceId madatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Front end Banner SDK for Linx Banner API customers
 
 ### CDN
 ```html
-<script src="//unpkg.com/linx-banner-client-js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@linx-impulse/banner-client-js/dist/linx-banner.min.js"></script>
 ```
 
 There will be created a property called **banner** in global linx object.
@@ -36,7 +36,7 @@ const LinxBanner = window.linx.banner;
 npm install --save @linx-impulse/banner-client-js
 ```
 
-It should be called this way:
+Using some module bundler like Webpack, it should be called this way:
 ```javascript
 
 const LinxBanner = require('@linx-impulse/banner-client-js');
@@ -51,8 +51,14 @@ import { BannerClient } from '@linx-impulse/banner-client-js';
   * options (object)
     * **page**(string): current page. Ex: home, product, category, subcategory, cart.
     * **source**(string): device of user. Ex: app, desktop, mobile.
-    * **deviceId**(string): device identifier.
     * **showLayout**(boolean): whether or not bring layout properties previously set. Default: `false`.
+    * **userId**(string): the user identifier, used to personalize slides even when user access a new device.
+    * **homologation**(boolean): enable banner homologation. With this feature enabled the disabled banners will be sent on api response.
+    * **timeout**(number): defines a timeout for request in milliseconds.
+    * **categories**(array): list of categories of the page. This information is used by api to apply the exhibition rules for banners.
+    * **product**(object): object containing product data. Useful for product pages.
+    * **tags**(array): array of tags of the page.
+    * **url**(string): url of the page.
 
 PS: *options* parameter is not required, neither any of these properties.
 
@@ -61,8 +67,51 @@ PS: *options* parameter is not required, neither any of these properties.
 LinxBanner.getRecommendations({
   page: 'home',
   source: 'desktop',
-  deviceId: 'usr2018abc',
   showLayout: true,
+  userId: 'user01',
+})
+  .then((banners) => {
+    console.log('Banners: ', banners);
+  })
+  .catch((error) => {
+    console.error('Banners error: ', error);
+  });
+```
+
+```javascript
+LinxBanner.getRecommendations({
+  page: 'product',
+  source: 'mobile',
+  showLayout: true,
+  product: {
+    id: 'prod001',
+  },
+  url: 'https://www.yourdomain/product/prod001'
+})
+  .then((banners) => {
+    console.log('Banners: ', banners);
+  })
+  .catch((error) => {
+    console.error('Banners error: ', error);
+  });
+```
+
+```javascript
+LinxBanner.getRecommendations({
+  page: 'subcategory',
+  source: 'desktop',
+  homologation: true,
+  showLayout: true,
+  categories: [
+    { id: 'cat01', parents: null },
+    { id: 'cat02', parents: [ 'cat01' ] },
+  ],
+  tags: [
+    { id: 'tag01' },
+    { id: 'tag02' },
+    { id: 'tag03' },
+  ],
+  url: 'https://www.yourdomain/category/cat01/cat02'
 })
   .then((banners) => {
     console.log('Banners: ', banners);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "npm run lint && karma start",
     "build": "webpack --config webpack.prod.js",
     "build:dev": "webpack --config webpack.dev.js",
-    "release": "npm test && standard-version && git push --follow-tags && npm publish"
+    "release": "npm test && npm run build && standard-version && git push --follow-tags && npm publish"
   },
   "repository": {
     "type": "git",
@@ -18,7 +18,12 @@
     "banner",
     "sdk",
     "js",
-    "linx"
+    "linx",
+    "linx impulse"
+  ],
+  "files": [
+    "src",
+    "dist"
   ],
   "contributors": [
     {

--- a/src/config.js
+++ b/src/config.js
@@ -3,7 +3,7 @@ export default {
     deviceId: 'chaordic_browserId',
   },
   server: {
-    baseUrl: '//banner.chaordicsystems.com/banner/v1',
+    baseUrl: '//api.linximpulse.com/engage/b/v1',
     recommendationUrl: '/recommendations',
   },
 };

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,7 @@
 export default {
+  cookieName: {
+    deviceId: 'chaordic_browserId',
+  },
   server: {
     baseUrl: '//banner.chaordicsystems.com/banner/v1',
     recommendationUrl: '/recommendations',

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -11,19 +11,8 @@ describe('BannerClient.getRecommendations', function () {
     this.ajaxStub.restore();
   });
 
-  it('should reject when no deviceId is provided', function () {
-    return BannerClient.getRecommendations({
-      page: 'home',
-      source: 'desktop',
-    }).catch((err) => {
-      expect(this.ajaxStub).to.not.have.been.called;
-      expect(err).to.be.instanceOf(TypeError);
-    });
-  });
-
   it('should reject when no page is provided', function () {
     return BannerClient.getRecommendations({
-      deviceId: 'device',
       source: 'desktop',
     }).catch((err) => {
       expect(this.ajaxStub).to.not.have.been.called;
@@ -33,7 +22,6 @@ describe('BannerClient.getRecommendations', function () {
 
   it('should reject when no source is provided', function () {
     return BannerClient.getRecommendations({
-      deviceId: 'device',
       page: 'home',
     }).catch((err) => {
       expect(this.ajaxStub).to.not.have.been.called;
@@ -43,7 +31,6 @@ describe('BannerClient.getRecommendations', function () {
 
   it('should make an ajax request with params provided', function () {
     const paramsClient = {
-      deviceId: 'device',
       source: 'desktop',
       page: 'home',
       showLayout: true,
@@ -53,7 +40,6 @@ describe('BannerClient.getRecommendations', function () {
     };
 
     const params = {
-      deviceId: 'device',
       page: 'home',
       source: 'desktop',
       showLayout: true,
@@ -78,7 +64,6 @@ describe('BannerClient.getRecommendations', function () {
 
   it('should resolve with data sent from ajax response', function () {
     const params = {
-      deviceId: 'device',
       source: 'desktop',
       page: 'home',
       showLayout: true,
@@ -97,7 +82,6 @@ describe('BannerClient.getRecommendations', function () {
 
   it('should reject with error sent from ajax request', function () {
     const params = {
-      deviceId: 'device',
       source: 'desktop',
       page: 'home',
       showLayout: true,
@@ -123,16 +107,15 @@ describe('BannerClient.getRecommendations', function () {
       {
         id: 'Livros',
         name:'Livros'
-      },  
+      },
       {
         id: 'Desenvolvimento Pessoal',
         name: 'Desenvolvimento Pessoal',
         parents: ['Autoajuda' ]
       }
     ];
-    
+
     const paramsClient = {
-      deviceId: 'device',
       source: 'desktop',
       page: 'home',
       showLayout: true,
@@ -141,12 +124,11 @@ describe('BannerClient.getRecommendations', function () {
 
     const params = {
       categoryId: ['Livros', 'Autoajuda', 'Desenvolvimento Pessoal'],
-      deviceId: 'device',
       homologation: undefined,
       page: 'home',
       productId: undefined,
-      showLayout: true, 
-      source: 'desktop',         
+      showLayout: true,
+      source: 'desktop',
       tagId: [],
       url: undefined,
       userId: undefined,
@@ -172,15 +154,14 @@ describe('BannerClient.getRecommendations', function () {
       {
         id: 'Livros',
         name:'Livros'
-      },  
+      },
       {
         id: 'Desenvolvimento Pessoal',
         name: 'Desenvolvimento Pessoal',
       }
     ];
-    
+
     const paramsClient = {
-      deviceId: 'device',
       source: 'desktop',
       page: 'home',
       showLayout: true,
@@ -189,12 +170,11 @@ describe('BannerClient.getRecommendations', function () {
 
     const params = {
       categoryId: [],
-      deviceId: 'device',
       homologation: undefined,
       page: 'home',
       productId: undefined,
-      showLayout: true, 
-      source: 'desktop',         
+      showLayout: true,
+      source: 'desktop',
       tagId: ['Autoajuda', 'Livros', 'Desenvolvimento Pessoal'],
       url: undefined,
       userId: undefined,
@@ -211,9 +191,8 @@ describe('BannerClient.getRecommendations', function () {
     });
   });
 
-  it('should pass product  to ajax request', function () {    
+  it('should pass product to ajax request', function () {
     const paramsClient = {
-      deviceId: 'device',
       source: 'desktop',
       page: 'home',
       showLayout: true,
@@ -222,12 +201,11 @@ describe('BannerClient.getRecommendations', function () {
 
     const params = {
       categoryId: [],
-      deviceId: 'device',
       homologation: undefined,
       page: 'home',
       productId: 'prd-00',
-      showLayout: true, 
-      source: 'desktop',         
+      showLayout: true,
+      source: 'desktop',
       tagId: [],
       url: undefined,
       userId: undefined,


### PR DESCRIPTION
Duas alterações feitas recentemente no contexto de subirmos os banners:

 - Alteramos o domínio da api de banners;
 - Removemos a obrigatoriedade do deviceId nos parâmetros da função de get. O fluxo será controlado pelo próprio banner-client. Não faz sentido uma aplicação externa que for utilizar o sdk ter que gerar esse valor.