### PR TITLE
feat: send search terms to banner server

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ import { BannerClient } from '@linx-impulse/banner-client-js';
     * **product**(object): object containing product data. Useful for product pages.
     * **tags**(array): array of tags of the page.
     * **url**(string): url of the page.
+    * **testGroup**(string): AB test group info.
+    * **searchQuery**(string): query terms used if in a search page.
 
 PS: *options* parameter is not required, neither any of these properties.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -186,9 +186,9 @@
       }
     },
     "@linx-impulse/commons-js": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@linx-impulse/commons-js/-/commons-js-3.2.1.tgz",
-      "integrity": "sha512-C6sJy0JZUWfZ3zVTCjOducTNA3Fv9D85aUVgJyZiUJ6/pJuThnkof/tZBWRslZ/yrQVTwPVEbvcxibK3MnpwVw=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@linx-impulse/commons-js/-/commons-js-3.5.0.tgz",
+      "integrity": "sha512-2MwDNjH6jVabxFzoGgRKIzfnuYjPayVfIiXA2wSBc0Yb0tERZsSISHKWCT8sgYNZkeO30GdffFTf41aPmKOkCw=="
     },
     "@sinonjs/commons": {
       "version": "1.0.2",
@@ -546,6 +546,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -557,6 +558,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -4005,7 +4007,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4420,7 +4423,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4476,6 +4480,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4519,12 +4524,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5966,7 +5973,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.3.1",

--- a/src/index.js
+++ b/src/index.js
@@ -84,6 +84,7 @@ export const BannerClient = {
     product,
     tags,
     url,
+    searchQuery,
   } = {}) {
     if (!page) {
       return Promise.reject(new TypeError('page is required to get banners'));
@@ -108,6 +109,7 @@ export const BannerClient = {
           productId: (product || {}).id,
           tagId: formattedTags(tags),
           url,
+          searchQuery,
         },
         success: resolve,
         error: reject,

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -269,4 +269,36 @@ describe('BannerClient.getRecommendations', function () {
         .calledWithMatch(sinon.match({ params }));
     });
   });
+
+  it('should pass searchQuery to ajax request', function() {
+    const paramsClient = {
+      source: 'desktop',
+      page: 'search',
+      showLayout: true,
+      searchQuery: 'lorem ipsum',
+    };
+
+    const params = {
+      categoryId: [],
+      homologation: undefined,
+      page: 'search',
+      productId: undefined,
+      showLayout: true,
+      source: 'desktop',
+      tagId: [],
+      url: undefined,
+      userId: undefined,
+      searchQuery: 'lorem ipsum',
+    };
+
+    this.ajaxStub.yieldsTo('success', {});
+
+    return BannerClient.getRecommendations(paramsClient).then(() => {
+      expect(this.ajaxStub)
+        .to
+        .have
+        .been
+        .calledWithMatch(sinon.match({ params }));
+    });
+  });
 });


### PR DESCRIPTION
Adiciona o parâmetro `searchTerms` à função `getRecommendations` e envia esse parâmetro na requisição para o banner server.