### PR TITLE
fix: check type product

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,7 @@ export const BannerClient = {
           homologation,
           testGroup,
           categoryId: formattedCategories(categories),
-          productId: (product || {}).id,
+          productId: (typeof product === 'string') ? product : (product || {}).id,
           tagId: formattedTags(tags),
           url,
           searchQuery,


### PR DESCRIPTION
Preparando o banner-client para receber o parâmetro de produto quando o mesmo for string.

Testar: através da PR https://github.com/chaordic/banner-js/pull/50