### PR TITLE
refactor: use formatCategories from commons-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -186,9 +186,9 @@
       }
     },
     "@linx-impulse/commons-js": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@linx-impulse/commons-js/-/commons-js-3.5.0.tgz",
-      "integrity": "sha512-2MwDNjH6jVabxFzoGgRKIzfnuYjPayVfIiXA2wSBc0Yb0tERZsSISHKWCT8sgYNZkeO30GdffFTf41aPmKOkCw=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@linx-impulse/commons-js/-/commons-js-4.2.1.tgz",
+      "integrity": "sha512-bzpnwME2Gq0Jg+Btw7jQXg2F86EwqYnQf7f/vM5b1WpFv0GnrYRnOCHHCaRddoX88pRRsJwU9ihioiVOXZNeGQ=="
     },
     "@sinonjs/commons": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,6 @@
     "webpack-merge": "^4.1.4"
   },
   "dependencies": {
-    "@linx-impulse/commons-js": "^3.3.0"
+    "@linx-impulse/commons-js": "^4.2.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import { ajax } from '@linx-impulse/commons-js/http/ajax';
-import { getCookie } from '@linx-impulse/commons-js/browser';
+import { getCookie } from '@linx-impulse/commons-js/browser/getCookie';
+import { formatCategories } from '@linx-impulse/commons-js/util/formatCategories';
 import config from './config';
 
 function formattedTags(tags) {
@@ -39,38 +40,6 @@ function getDeviceId() {
   return id;
 }
 
-function getFirstChild(categories, item) {
-  return (categories || []).find(category => (
-    !category.used
-    && Array.isArray(category.parents)
-    && category.parents.indexOf(item.id) !== -1
-  ));
-}
-
-function formattedCategories(categories) {
-  // Filter wrong formatted
-  const filteredCategories = (categories || [])
-    .filter(category => category && category.id)
-    .map(category => ({ id: category.id, parents: category.parents }));
-
-  // Find the root node
-  let item = filteredCategories.find(category => (
-    (
-      !category.parents || (
-        Array.isArray(category.parents) && !category.parents.length
-      )
-    )
-  ));
-  const ids = [];
-
-  while (typeof item === 'object') {
-    ids.push(item.id);
-    item.used = true;
-    item = getFirstChild(filteredCategories, item);
-  }
-  return ids;
-}
-
 export const BannerClient = {
   getRecommendations({
     page,
@@ -105,7 +74,7 @@ export const BannerClient = {
           userId,
           homologation,
           testGroup,
-          categoryId: formattedCategories(categories),
+          categoryId: formatCategories(categories),
           productId: (typeof product === 'string') ? product : (product || {}).id,
           tagId: formattedTags(tags),
           url,

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -97,7 +97,7 @@ describe('BannerClient.getRecommendations', function () {
       .rejectedWith(err);
   });
 
-  it('should pass formattedCategories to ajax request', function () {
+  it('should pass formatted categories to ajax request', function () {
     const categories = [
       {
         id: 'Autoajuda',


### PR DESCRIPTION
Com o advento da implementação do formattedCategories no commons-js estaremos usando o banner-client-js como primeiro caso uso. Removendo a função daqui e em vez disso importando e usando a que foi implementada no commons.

Para testar seguir as instruções na PR do banner-js (https://github.com/chaordic/banner-js/pull/52). Also rodar os testes com `npm run test`.